### PR TITLE
fix: report correct FOSSIL_ADDRESS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ app.get('/', (req, res) =>
     port: PORT,
     starknet_address: process.env.STARKNET_ADDRESS || '',
     eth_address: process.env.ETH_ADDRESS || '',
-    fossil_address: process.env.ETH_ADDRESS || ''
+    fossil_address: process.env.FOSSIL_ADDRESS || ''
   })
 );
 


### PR DESCRIPTION
We reported `ETH_ADDRESS` instead of `FOSSIL_ADDRESS`