### PR TITLE
fix: use goerli2 for fossil

### DIFF
--- a/src/fossil.ts
+++ b/src/fossil.ts
@@ -4,7 +4,8 @@ import { Wallet } from '@ethersproject/wallet';
 import { Contract } from '@ethersproject/contracts';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { utils } from '@snapshot-labs/sx';
-import { defaultProvider, Account, ec } from 'starknet';
+import { Account, ec } from 'starknet';
+import { starkProvider } from './starkProvider';
 
 const ethPrivkey = process.env.ETH_PRIVKEY || '';
 const ethRpcUrl = process.env.ETH_RPC_URL || '';
@@ -21,7 +22,8 @@ const abi = ['function sendExactParentHashToL2(uint256)', 'function sendLatestPa
 const starknetPrivkey = process.env.STARKNET_PRIVKEY || '';
 const starknetAddress = process.env.STARKNET_ADDRESS || '';
 const starkKeyPair = ec.getKeyPair(starknetPrivkey);
-const starknetAccount = new Account(defaultProvider, starknetAddress, starkKeyPair);
+
+const starknetAccount = new Account(starkProvider, starknetAddress, starkKeyPair);
 
 async function sendExactParentHashToL2(blockNumber: number) {
   const contract = new Contract(fossilAddress, abi);

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -1,19 +1,13 @@
 import fetch from 'cross-fetch';
 global.fetch = fetch;
 import express from 'express';
-import { Account, Provider, ec, constants } from 'starknet';
+import { Account, ec } from 'starknet';
 import { clients } from '@snapshot-labs/sx';
 import { rpcError, rpcSuccess } from './utils';
+import { starkProvider } from './starkProvider';
 
 const starknetPrivkey = process.env.STARKNET_PRIVKEY || '';
 const starknetAddress = process.env.STARKNET_ADDRESS || '';
-
-const starkProvider = new Provider({
-  sequencer: {
-    baseUrl: 'https://alpha4-2.starknet.io',
-    chainId: constants.StarknetChainId.TESTNET2
-  }
-});
 
 const client = new clients.StarkNetTx({
   starkProvider,

--- a/src/starkProvider.ts
+++ b/src/starkProvider.ts
@@ -1,0 +1,8 @@
+import { Provider, constants } from 'starknet';
+
+export const starkProvider = new Provider({
+  sequencer: {
+    baseUrl: 'https://alpha4-2.starknet.io',
+    chainId: constants.StarknetChainId.TESTNET2
+  }
+});


### PR DESCRIPTION
## Summary

Fossil endpoint was still using goerli1 provider.