### PR TITLE
feat: add multinetwork support for ETH rpc

### DIFF
--- a/src/eth/dependencies.ts
+++ b/src/eth/dependencies.ts
@@ -1,19 +1,15 @@
-import { JsonRpcProvider } from '@ethersproject/providers';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
 import { NonceManager } from '@ethersproject/experimental';
-
-const ethMnemonic = process.env.ETH_MNEMONIC || '';
-const ethRpcUrl = process.env.ETH_RPC_URL || '';
 
 const addressIndicies = {
   // SekhmetDAO
   '0x65e4329e8c0fba31883b98e2cf3e81d3cdcac780': 1
 };
 
-export const provider = new JsonRpcProvider(ethRpcUrl);
-
-export const createWalletProxy = (mnemonic: string) => {
+export const createWalletProxy = (mnemonic: string, chainId: number) => {
   const signers = new Map<string, NonceManager>();
+  const provider = new StaticJsonRpcProvider(`https://rpc.snapshotx.xyz/${chainId}`);
 
   return (spaceAddress: string) => {
     const normalizedSpaceAddress = spaceAddress.toLowerCase();
@@ -29,5 +25,3 @@ export const createWalletProxy = (mnemonic: string) => {
     return signers.get(normalizedSpaceAddress) as NonceManager;
   };
 };
-
-export const getWallet = createWalletProxy(ethMnemonic);

--- a/src/eth/index.ts
+++ b/src/eth/index.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import { createNetworkHandler, NETWORKS } from './rpc';
+
+const router = express.Router();
+
+const handlers = Object.fromEntries(
+  Object.keys(NETWORKS).map(chainId => [chainId, createNetworkHandler(parseInt(chainId, 10))])
+);
+
+router.post('/:chainId?', (req, res) => {
+  const chainId = req.params.chainId || '5';
+  const handler = handlers[chainId];
+
+  const { id, method, params } = req.body;
+  handler[method](id, params, res);
+});
+
+export default router;

--- a/src/eth/rpc.ts
+++ b/src/eth/rpc.ts
@@ -1,92 +1,97 @@
-import express from 'express';
-import { clients } from '@snapshot-labs/sx';
-import { getWallet } from './dependencies';
+import { clients, evmGoerli, evmSepolia, evmLineaGoerli } from '@snapshot-labs/sx';
+import { createWalletProxy } from './dependencies';
 import { rpcError, rpcSuccess } from '../utils';
 
-const client = new clients.EvmEthereumTx();
+export const NETWORKS = {
+  5: evmGoerli,
+  11155111: evmSepolia,
+  59140: evmLineaGoerli
+} as const;
 
-const router = express.Router();
+export const createNetworkHandler = (chainId: number) => {
+  const networkConfig = NETWORKS[chainId];
+  if (!networkConfig) throw new Error('Unsupported chainId');
 
-async function send(id, params, res) {
-  try {
-    const { signatureData, data } = params.envelope;
-    const { types } = signatureData;
-    let receipt;
+  const getWallet = createWalletProxy(process.env.ETH_MNEMONIC || '', chainId);
 
-    const signer = getWallet(params.envelope.data.space);
+  const client = new clients.EvmEthereumTx({ networkConfig: networkConfig });
 
-    console.time('Send');
-    console.log('Types', types);
-    console.log('Message', data);
+  async function send(id, params, res) {
+    console.log('networkConfig', networkConfig);
 
-    if (types.Propose) {
-      receipt = await client.propose({
-        signer,
-        envelope: params.envelope
-      });
-    } else if (types.updateProposal) {
-      receipt = await client.updateProposal({
-        signer,
-        envelope: params.envelope
-      });
-    } else if (types.Vote) {
-      receipt = await client.vote({
-        signer,
-        envelope: params.envelope
-      });
+    try {
+      const { signatureData, data } = params.envelope;
+      const { types } = signatureData;
+      let receipt;
+
+      const signer = getWallet(params.envelope.data.space);
+
+      console.time('Send');
+      console.log('Types', types);
+      console.log('Message', data);
+
+      if (types.Propose) {
+        receipt = await client.propose({
+          signer,
+          envelope: params.envelope
+        });
+      } else if (types.updateProposal) {
+        receipt = await client.updateProposal({
+          signer,
+          envelope: params.envelope
+        });
+      } else if (types.Vote) {
+        receipt = await client.vote({
+          signer,
+          envelope: params.envelope
+        });
+      }
+
+      console.log('Receipt', receipt);
+
+      return rpcSuccess(res, receipt, id);
+    } catch (e) {
+      console.log('Failed', e);
+      return rpcError(res, 500, e, id);
+    } finally {
+      console.timeEnd('Send');
     }
-
-    console.log('Receipt', receipt);
-
-    return rpcSuccess(res, receipt, id);
-  } catch (e) {
-    console.log('Failed', e);
-    return rpcError(res, 500, e, id);
-  } finally {
-    console.timeEnd('Send');
   }
-}
 
-async function execute(id, params, res) {
-  try {
-    const { space, proposalId, executionParams } = params;
-    const signer = getWallet(space);
+  async function execute(id, params, res) {
+    try {
+      const { space, proposalId, executionParams } = params;
+      const signer = getWallet(space);
 
-    const receipt = await client.execute({
-      signer,
-      space,
-      proposal: proposalId,
-      executionParams
-    });
+      const receipt = await client.execute({
+        signer,
+        space,
+        proposal: proposalId,
+        executionParams
+      });
 
-    return rpcSuccess(res, receipt, id);
-  } catch (e) {
-    return rpcError(res, 500, e, id);
+      return rpcSuccess(res, receipt, id);
+    } catch (e) {
+      return rpcError(res, 500, e, id);
+    }
   }
-}
 
-async function executeQueuedProposal(id, params, res) {
-  try {
-    const { space, executionStrategy, executionParams } = params;
-    const signer = getWallet(space);
+  async function executeQueuedProposal(id, params, res) {
+    try {
+      const { space, executionStrategy, executionParams } = params;
+      const signer = getWallet(space);
 
-    const receipt = await client.executeQueuedProposal({
-      signer,
-      executionStrategy,
-      executionParams
-    });
+      const receipt = await client.executeQueuedProposal({
+        signer,
+        executionStrategy,
+        executionParams
+      });
 
-    return rpcSuccess(res, receipt, id);
-  } catch (e) {
-    return rpcError(res, 500, e, id);
+      return rpcSuccess(res, receipt, id);
+    } catch (e) {
+      return rpcError(res, 500, e, id);
+    }
   }
-}
 
-const fn = { send, execute, executeQueuedProposal };
-
-router.post('/', async (req, res) => {
-  const { id, method, params } = req.body;
-  return await fn[method](id, params, res);
-});
-
-export default router;
+  return { send, execute, executeQueuedProposal };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import rpc from './rpc';
-import ethRpc from './eth/rpc';
+import ethRpc from './eth';
 import fossil from './fossil';
 import space from './space';
 import pkg from '../package.json';


### PR DESCRIPTION
Now it's accessible through /eth_rpc/:chainId

This enables Sepolia/Linea support.

Depends on: https://github.com/snapshot-labs/sx.js/pull/196