### PR TITLE
chore: bump @snapshot-labs/sx to v0.1.0-beta.39

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@ethersproject/experimental": "5.7.0",
     "@ethersproject/providers": "^5.7.0",
     "@ethersproject/wallet": "^5.7.0",
-    "@snapshot-labs/sx": "^0.1.0-beta.35",
+    "@snapshot-labs/sx": "^0.1.0-beta.39",
     "connection-string": "^4.4.0",
     "cors": "^2.8.5",
     "cross-fetch": "^3.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -514,10 +514,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
-"@snapshot-labs/sx@^0.1.0-beta.35":
-  version "0.1.0-beta.35"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.35.tgz#443a984c1c89ad0becdb67dbcfdb2d7776c887c7"
-  integrity sha512-f9KqjXTEGNbwnTMkFOdiZm2MC6LbTIJRsVl/ksAIXAmXYhksFJvAl8k8rv7AW6GOmJFq4CBU6O9KfczeMnkzrQ==
+"@snapshot-labs/sx@^0.1.0-beta.39":
+  version "0.1.0-beta.39"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.39.tgz#04495cadae063030b985b3aa4426ff0be8ff6e76"
+  integrity sha512-4NamhFX/zU3V6kJNLd2YmlM3guWjMYuByTwF5CQTMKXpS9c4/th8KE0AJQw8Ewmq970kYh9/7aMS/UVPYEE4DQ==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/abstract-signer" "^5.7.0"


### PR DESCRIPTION
To enable merkletree whitelist strategy.