### PR TITLE
feat: add herodotus support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,6 @@ ETH_RPC_URL=https://rpc.brovider.xyz/5
 STARKNET_MAINNET_RPC_URL=https://starknet-mainnet.infura.io/v3/46a5dd9727bf48d4a132672d3f376146
 STARKNET_GOERLI_RPC_URL=https://starknet-goerli.infura.io/v3/46a5dd9727bf48d4a132672d3f376146
 FOSSIL_ADDRESS=
+HERODOTUS_API_KEY=
 DATABASE_URL=postgres://postgres:password@localhost:5432/mana
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@ethersproject/wallet": "^5.7.0",
     "@scure/bip32": "^1.3.3",
     "@scure/bip39": "^1.2.2",
-    "@snapshot-labs/sx": "^0.1.0-beta.46",
+    "@snapshot-labs/sx": "^0.1.0-beta.49",
     "abi-wan-kanabi": "^2.0.0",
     "connection-string": "^4.4.0",
     "cors": "^2.8.5",

--- a/src/stark/herodotus.ts
+++ b/src/stark/herodotus.ts
@@ -52,9 +52,9 @@ export async function registerProposal({
   } else {
     console.log('WARN! webhooks disabled');
     console.log('you will need to manually inform server about new storage root being accepted');
-    console.log('by visting this URL:');
-    console.log(webhookUrl);
   }
+
+  console.log('Webhook URL', webhookUrl);
 
   const res = await fetch(
     `https://api.herodotus.cloud/submit-batch-query?apiKey=${process.env.HERODOTUS_API_KEY}`,

--- a/src/stark/herodotus.ts
+++ b/src/stark/herodotus.ts
@@ -69,7 +69,7 @@ export async function registerProposal({
 
   const result = await res.json();
 
-  console.log('herodotus internalId', result, result.internalId);
+  console.log('herodotus internalId', result.internalId);
 
   return result;
 }

--- a/src/stark/herodotus.ts
+++ b/src/stark/herodotus.ts
@@ -1,0 +1,107 @@
+import fetch from 'cross-fetch';
+import { Account, constants } from 'starknet';
+import { clients } from '@snapshot-labs/sx';
+
+const controller = new clients.HerodotusController();
+
+const WEBHOOK_ENABLED = process.env.WEBHOOK_ENABLED;
+const WEBHOOK_BASE_URL =
+  process.env.WEBHOOK_BASE_URL || `http://localhost:${process.env.PORT || 3000}`;
+const WEBHOOK_KEY = process.env.WEBHOOK_KEY || '212121424242';
+
+export async function registerProposal({
+  chainId,
+  l1TokenAddress,
+  strategyAddress,
+  snapshotTimestamp
+}: {
+  chainId: string;
+  l1TokenAddress: string;
+  strategyAddress: string;
+  snapshotTimestamp: number;
+}) {
+  const webhookUrl = `${WEBHOOK_BASE_URL}/stark_rpc/${chainId}/storage-webhook?timestamp=${snapshotTimestamp}&strategyAddress=${strategyAddress}&key=${WEBHOOK_KEY}`;
+
+  if (chainId !== constants.StarknetChainId.SN_GOERLI) {
+    throw new Error('Only Starknet goerli is supported');
+  }
+
+  const body: any = {
+    destinationChainId: 'SN_GOERLI',
+    fee: '0',
+    data: {
+      '5': {
+        [`timestamp:${snapshotTimestamp}`]: {
+          accounts: {
+            [l1TokenAddress]: {
+              props: ['STORAGE_ROOT']
+            }
+          }
+        }
+      }
+    }
+  };
+
+  if (WEBHOOK_ENABLED) {
+    body.webhook = {
+      url: webhookUrl,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    };
+  } else {
+    console.log('WARN! webhooks disabled');
+    console.log('you will need to manually inform server about new storage root being accepted');
+    console.log('by visting this URL:');
+    console.log(webhookUrl);
+  }
+
+  const res = await fetch(
+    `https://api.herodotus.cloud/submit-batch-query?apiKey=${process.env.HERODOTUS_API_KEY}`,
+    {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    }
+  );
+
+  const result = await res.json();
+
+  console.log('herodotus internalId', result, result.internalId);
+
+  return result;
+}
+
+export async function handleStorageWebhook({
+  account,
+  timestamp,
+  strategyAddress,
+  key
+}: {
+  account: Account;
+  timestamp: number;
+  strategyAddress: string;
+  key: string;
+}) {
+  if (key !== WEBHOOK_KEY) throw new Error('Invalid key');
+
+  const res = await fetch(
+    `https://ds-indexer.api.herodotus.cloud/binsearch-path?timestamp=${timestamp}&deployed_on_chain=SN_GOERLI&accumulates_chain=5`,
+    {
+      headers: {
+        accept: 'application/json'
+      }
+    }
+  );
+
+  const tree = await res.json();
+
+  return controller.cacheTimestamp({
+    signer: account,
+    contractAddress: strategyAddress,
+    timestamp,
+    binaryTree: tree
+  });
+}

--- a/src/stark/index.ts
+++ b/src/stark/index.ts
@@ -2,12 +2,34 @@ import express from 'express';
 import { createNetworkHandler } from './rpc';
 import { NETWORKS } from './networks';
 import { DEFAULT_INDEX, SPACES_INDICIES, getStarknetAccount } from './dependencies';
+import { handleStorageWebhook } from './herodotus';
 
 const router = express.Router();
 
 const handlers = Object.fromEntries(
   Object.keys(NETWORKS).map(chainId => [chainId, createNetworkHandler(chainId)])
 );
+
+router.get('/:chainId/storage-webhook', async (req, res) => {
+  const chainId = req.params.chainId;
+  const handler = handlers[chainId];
+
+  const { timestamp, strategyAddress, key } = req.query;
+  if (!timestamp || !strategyAddress || !key) {
+    return res.status(400).json({ error: 'Missing required params' });
+  }
+
+  const result = await handleStorageWebhook({
+    account: handler.getAccount('0x0'), // we can't reliably get space address for this callback, it's only one call per proposal, should be fine
+    timestamp: parseInt(timestamp.toString(), 10),
+    strategyAddress: strategyAddress.toString(),
+    key: key.toString()
+  });
+
+  res.json({
+    result
+  });
+});
 
 router.post('/:chainId', (req, res) => {
   const chainId = req.params.chainId;

--- a/src/stark/networks.ts
+++ b/src/stark/networks.ts
@@ -11,7 +11,7 @@ const clientsMap = new Map<
   string,
   {
     provider: RpcProvider;
-    client: clients.StarkNetTx;
+    client: clients.StarknetTx;
     getAccount: (spaceAddress) => Account;
   }
 >();
@@ -23,7 +23,7 @@ export function getClient(chainId: string) {
   const provider = getProvider(chainId);
   const getAccount = createAccountProxy(process.env.STARKNET_MNEMONIC || '', provider);
 
-  const client = new clients.StarkNetTx({
+  const client = new clients.StarknetTx({
     starkProvider: provider,
     ethUrl: process.env.ETH_RPC_URL as string,
     networkConfig: NETWORKS[chainId]

--- a/src/stark/rpc.ts
+++ b/src/stark/rpc.ts
@@ -62,6 +62,19 @@ export const createNetworkHandler = (chainId: string) => {
     try {
       const { l1TokenAddress, strategyAddress, snapshotTimestamp } = params;
 
+      const alreadyRegistered = await db.getProposal(
+        `${chainId}-${l1TokenAddress}-${strategyAddress}-${snapshotTimestamp}`
+      );
+      if (alreadyRegistered) {
+        return rpcSuccess(
+          res,
+          {
+            alreadyRegistered: true
+          },
+          id
+        );
+      }
+
       console.log('Registering proposal', l1TokenAddress, strategyAddress, snapshotTimestamp);
 
       const result = await herodotus.registerProposal({
@@ -70,6 +83,10 @@ export const createNetworkHandler = (chainId: string) => {
         strategyAddress,
         snapshotTimestamp
       });
+
+      await db.registerProposal(
+        `${chainId}-${l1TokenAddress}-${strategyAddress}-${snapshotTimestamp}`
+      );
 
       return rpcSuccess(res, result, id);
     } catch (e) {

--- a/src/stark/rpc.ts
+++ b/src/stark/rpc.ts
@@ -1,5 +1,6 @@
 import { NETWORKS, getClient } from './networks';
 import * as db from '../db';
+import * as herodotus from './herodotus';
 import { rpcError, rpcSuccess } from '../utils';
 
 export const createNetworkHandler = (chainId: string) => {
@@ -57,5 +58,25 @@ export const createNetworkHandler = (chainId: string) => {
     }
   }
 
-  return { send, registerTransaction };
+  async function registerProposal(id, params, res) {
+    try {
+      const { l1TokenAddress, strategyAddress, snapshotTimestamp } = params;
+
+      console.log('Registering proposal', l1TokenAddress, strategyAddress, snapshotTimestamp);
+
+      const result = await herodotus.registerProposal({
+        chainId,
+        l1TokenAddress,
+        strategyAddress,
+        snapshotTimestamp
+      });
+
+      return rpcSuccess(res, result, id);
+    } catch (e) {
+      console.log('Failed', e);
+      return rpcError(res, 500, e, id);
+    }
+  }
+
+  return { send, registerTransaction, registerProposal, getAccount };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -689,10 +689,10 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.11.tgz#d8caa8fc32252ac265fa4de5b8478ce3cac867b2"
   integrity sha512-/OiQgEkNpMJqDfTDYXggDDxLX6YYQ7n3GZfWRqnUJTlf6YNfkurBC2pVTkN1iHJOI/Vx1Aq/v3D8Ss907k+MMg==
 
-"@snapshot-labs/sx@^0.1.0-beta.46":
-  version "0.1.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.46.tgz#b8b2f40586e26d08d0c82f7ecae18c31b42af848"
-  integrity sha512-YueEnTItdMxdRC/EL2SZ9ijxY/VRxbNToFa71/yKZavKCdBxxrOTIWit9ctzKrjidpS+HSewUD6w7bCuUYFh4g==
+"@snapshot-labs/sx@^0.1.0-beta.49":
+  version "0.1.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.49.tgz#bc96b0ea62809ac7c88d25c81df3a6972cc5db7e"
+  integrity sha512-98d/izATRuW5GnUVdBiGi6DSWS5I4Wd8GJoFISOiPMED4duXLx4qVFk8ad0odI/N13/hopF7L+QhoqmWsHzRUw==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/abstract-signer" "^5.7.0"


### PR DESCRIPTION
Depends on: https://github.com/snapshot-labs/sx.js/pull/243

This PR adds herodotus support.

Flow is as follows:
1. sx-api finds new proposal using EvmSlotValue strategy.
2. It registers that proposal on mana.
3. Mana submits batch request to herodotus and optionally registers a webhook - in development it will instead provide URL that you can call yourself).
4. Check https://api.herodotus.cloud/batch-query-status?apiKey=API_KEY&batchQueryId=INTERNAL_ID_RETURNED_BY_MANA
4. Webhooks gets triggered once status is DONE (or you do it yourself by visiting provided webhook link if WEBHOOK_ENABLED is not set).
5. Voting power is now active.

## Test plan
1. Link sx.js
2. Set HERODOTUS_API_KEY.
3. Run mana (maybe on port 3001 as you need sx-api as well). Make sure sx-ui is pointing to it.
